### PR TITLE
Fix unit error.

### DIFF
--- a/R/facet_share.R
+++ b/R/facet_share.R
@@ -145,8 +145,8 @@ FacetShare <- ggproto("FacetShare", ggplot2::FacetWrap,
         
       shared_axis <- gtable::gtable_matrix(
         "shared.ax.y", shared_axis,
-        widths = unit(c(axes$y$left[[1]]$children$axis$widths[[tick_idx]], 1,
-                        axes$y$left[[1]]$children$axis$widths[[tick_idx]]),
+        widths = unit(c(as.numeric(axes$y$left[[1]]$children$axis$widths[[tick_idx]]), 1,
+                        as.numeric(axes$y$left[[1]]$children$axis$widths[[tick_idx]])),
                       c("pt", "grobwidth", "pt"),
                       list(NULL, axes$y$left[[1]]$children$axis$grobs[[lab_idx]], NULL)),
         heights = unit(1, "npc"), clip = "off")


### PR DESCRIPTION
This commit fixes an error when creating basic shared axes:

    library(ggplot2)
    ggplot(mtcars, aes(x = hp, y = mpg)) + geom_bar(stat = "identity") + facet_share(~am)

> 
> Error in unit(c(axes$y$left[[1]]$children$axis$widths[[tick_idx]], 1,  : 
>   'list' object cannot be coerced to type 'double'